### PR TITLE
Accept higher dynogels versions too

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     "bluebird": "^3.4.6"
   },
   "peerDependencies": {
-    "dynogels": "6.x.x"
+    "dynogels": ">=6.0.0"
   }
 }


### PR DESCRIPTION
Dynogels has released a new major version. Even though it's a major version in dynogels, nothing changes in the API that breaks `dynogels-profisified` therefore my PR, extending the peerDependency version range.
